### PR TITLE
Example and test cleanup

### DIFF
--- a/accumulate/accumulate.t
+++ b/accumulate/accumulate.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 8;
 

--- a/accumulate/accumulate.t
+++ b/accumulate/accumulate.t
@@ -4,7 +4,13 @@ use lib './';
 
 plan 8;
 
-BEGIN { EVAL('use Example') }; pass 'Load module';
+BEGIN {
+  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Accumulate';
+  EVAL("use $module")
+};
+
+pass 'Load module';
+
 ok Accumulate.can('accumulate'), 'Accumulate class has accumulate() method';
 
 is-deeply Accumulate.accumulate([ ], sub {}),

--- a/anagram/Example.pm
+++ b/anagram/Example.pm
@@ -3,7 +3,7 @@ class Anagram {
         my @results;
         my $canonical = self!canonize($word);
         for @words -> $w {
-            next if $w eq $word;
+            next if $w.lc eq $word.lc;
             my $try = self!canonize($w);
             if $try eq $canonical {
                 @results.push: $w;

--- a/anagram/anagram.t
+++ b/anagram/anagram.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 11;
 

--- a/anagram/anagram.t
+++ b/anagram/anagram.t
@@ -2,15 +2,14 @@ use v6;
 use Test;
 use lib './';
 
-BEGIN {
-    plan 11;
+plan 11;
 
-    my @files = <Example Anagram>;
-    my $file = @files.grep({ ( $_ ~ '.pm' ).IO.f })[0] 
-        or exit flunk "neither " ~ ( @files.map({ $_ ~ '.pm' }).join( ' or ' ) ) ~ ' found';
-    EVAL( 'use ' ~ $file );
-    pass 'Load module';
-}
+BEGIN {
+  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Anagram';
+  EVAL("use $module")
+};
+
+pass 'Load module';
 
 ok Anagram.can('match'), 'Class Anagram has match method';
 

--- a/binary/Example.pm
+++ b/binary/Example.pm
@@ -5,7 +5,7 @@ class Binary {
         my $decimal = 0;
         my $index = $binary.chars;
 
-        for $binary.split('') -> $bit {
+        for $binary.split('',:skip-empty) -> $bit {
            $decimal += $bit * 2 ** --$index;
         }
         return $decimal;

--- a/binary/binary.t
+++ b/binary/binary.t
@@ -2,15 +2,14 @@ use v6;
 use Test;
 use lib './';
 
-BEGIN {
-    plan 10;
+plan 10;
 
-    my @files = <Example Binary>;
-    my $file = @files.grep({ ( $_ ~ '.pm' ).IO.f })[0] 
-        or exit flunk "neither " ~ ( @files.map({ $_ ~ '.pm' }).join( ' or ' ) ) ~ ' found';
-    EVAL( 'use ' ~ $file );
-    pass 'Load module';
-}
+BEGIN {
+  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Anagram';
+  EVAL("use $module")
+};
+
+pass 'Load module';
 
 ok Binary.can('to_decimal'), 'Class Binary has to_decimal method';
 

--- a/binary/binary.t
+++ b/binary/binary.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 10;
 

--- a/bob/bob.t
+++ b/bob/bob.t
@@ -4,10 +4,8 @@ use lib './';
 
 plan 21;
 
-
 BEGIN { 
     my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Bob';
-
     EVAL("use $module");
 }; 
 

--- a/bob/bob.t
+++ b/bob/bob.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 21;
 

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/exercism/xperl6",
   "checklist_issue": 30,
   "active": false,
+  "test_pattern": ".*\\.t$",
   "deprecated": [
 
   ],

--- a/grains/grains.t
+++ b/grains/grains.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 11;
 

--- a/grains/grains.t
+++ b/grains/grains.t
@@ -4,7 +4,12 @@ use lib './';
 
 plan 11;
 
-BEGIN { EVAL('use Example') }; pass 'Load module';
+BEGIN {
+  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Grains';
+  EVAL("use $module")
+};
+
+pass 'Load module';
 
 ok Grains.can('square'), 'Grains class has square method';
 ok Grains.can('total'), 'Grains class has total method';

--- a/leap/leap.t
+++ b/leap/leap.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 8;
 

--- a/leap/leap.t
+++ b/leap/leap.t
@@ -9,6 +9,8 @@ BEGIN {
     EVAL("use $module");
 };
 
+pass 'Load module';
+
 ok Leap.can('is_leap'), 'Leap class has is_leap() method';
 
 ok my $leap = Leap.new, 'Create new Leap object';

--- a/raindrops/raindrops.t
+++ b/raindrops/raindrops.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 18;
 

--- a/raindrops/raindrops.t
+++ b/raindrops/raindrops.t
@@ -4,7 +4,13 @@ use lib './';
 
 plan 18;
 
-BEGIN { EVAL('use Example') }; pass ('Load module');
+BEGIN {
+  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Raindrops';
+  EVAL("use $module")
+};
+
+pass 'Load module';
+
 
 ok Raindrops.can('convert'), 'Class Raindrops has convert method';
 

--- a/rna-transcription/rna_transcription.t
+++ b/rna-transcription/rna_transcription.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 7;
 

--- a/rna-transcription/rna_transcription.t
+++ b/rna-transcription/rna_transcription.t
@@ -2,15 +2,14 @@ use v6;
 use Test;
 use lib './';
 
-BEGIN {
-    plan 7;
+plan 7;
 
-    my @files = <Example DNA>;
-    my $file = @files.grep({ ( $_ ~ '.pm' ).IO.f })[0] 
-        or exit flunk "neither " ~ ( @files.map({ $_ ~ '.pm' }).join( ' or ' ) ) ~ ' found';
-    EVAL( 'use ' ~ $file );
-    pass 'Load module';
-}
+BEGIN { 
+    my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'RNA_Transcription';
+    EVAL("use $module");
+}; 
+
+pass 'Load module';
 
 ok RNA_Transcription.can('to_rna'), 'Class RNA_Transcription has to_rna() method';
 

--- a/robot-name/robot.t
+++ b/robot-name/robot.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 7;
 

--- a/robot-name/robot.t
+++ b/robot-name/robot.t
@@ -2,15 +2,14 @@ use v6;
 use Test;
 use lib './';
 
-BEGIN {
-    plan 7;
+plan 7;
 
-    my @files = <Example Robot>;
-    my $file = @files.grep({ ( $_ ~ '.pm' ).IO.f })[0] 
-        or exit flunk "neither " ~ ( @files.map({ $_ ~ '.pm' }).join( ' or ' ) ) ~ ' found';
-    EVAL( 'use ' ~ $file );
-    pass 'Load module';
-}
+BEGIN { 
+    my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Robot';
+    EVAL("use $module");
+}; 
+
+pass 'Load module';
 
 ok Robot.can('name'), 'Robot class has name attribute';
 ok Robot.can('reset_name'), 'Robot class has reset_name method';

--- a/scrabble-score/Example.pm
+++ b/scrabble-score/Example.pm
@@ -13,7 +13,7 @@ class Scrabble {
     method score ($word) {
         my $score = 0;
 
-        for $word.lc.split('') -> $letter {
+        for $word.lc.split('',:skip-empty) -> $letter {
             $score
             += self.values{ self.values.keys.first(/$letter/) or 'ZERO' };
         }

--- a/scrabble-score/scrabble_score.t
+++ b/scrabble-score/scrabble_score.t
@@ -4,7 +4,13 @@ use lib './';
 
 plan 10;
 
-BEGIN { EVAL('use Example') }; pass 'Load module';
+BEGIN {
+  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Scrabble';
+  EVAL("use $module")
+};
+
+pass 'Load module';
+
 ok Scrabble.can('score'), 'Scrabble class has score() method';
 
 my $scrabble = Scrabble.new();

--- a/scrabble-score/scrabble_score.t
+++ b/scrabble-score/scrabble_score.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 10;
 

--- a/word-count/word_count.t
+++ b/word-count/word_count.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-use lib './';
+use lib IO::Path.new($?FILE).parent.path;
 
 plan 8;
 

--- a/word-count/word_count.t
+++ b/word-count/word_count.t
@@ -4,7 +4,13 @@ use lib './';
 
 plan 8;
 
-BEGIN { EVAL('use Example') }; pass 'Load module';
+BEGIN {
+  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Word_Counter';
+  EVAL("use $module")
+};
+
+pass 'Load module';
+
 
 ok Word_Counter.can('count_words'), 'Class Word_Counter has count_words method';
 


### PR DESCRIPTION
1. Some tests were only looking for Example files. These now look for the relevant modules.
2. Some tests would only look for files with the extension '.pm'. Changes now allow files to use other extensions e.g. pm6.
3. Some examples were failing tests. Small adjustments were made to allow them to pass again.
4. `use lib` has been changed on all tests so that the tests look in their own directory for the appropriate modules.
5. test_pattern added to config.json

```
$ EXERCISM=1 prove --exec perl6 */*.t
accumulate/accumulate.t ................ ok   
anagram/anagram.t ...................... ok     
binary/binary.t ........................ ok     
bob/bob.t .............................. ok     
grains/grains.t ........................ ok     
leap/leap.t ............................ ok   
raindrops/raindrops.t .................. ok     
rna-transcription/rna_transcription.t .. ok   
robot-name/robot.t ..................... ok   
scrabble-score/scrabble_score.t ........ ok     
word-count/word_count.t ................ ok   
All tests successful.
Files=11, Tests=119,  4 wallclock secs ( 0.04 usr  0.01 sys +  3.08 cusr  0.23 csys =  3.36 CPU)
Result: PASS

```
