### PR TITLE
Replace 'pass' with proper test

### DIFF
--- a/exercises/accumulate/accumulate.t
+++ b/exercises/accumulate/accumulate.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 8;
-
 BEGIN {
-  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Accumulate';
-  EVAL("use $module")
-};
-
-pass 'Load module';
+  plan 8;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Accumulate', 'Module loaded';
+}
 
 ok Accumulate.can('accumulate'), 'Accumulate class has accumulate() method';
 

--- a/exercises/anagram/anagram.t
+++ b/exercises/anagram/anagram.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 11;
-
 BEGIN {
-  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Anagram';
-  EVAL("use $module")
-};
-
-pass 'Load module';
+  plan 11;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Anagram', 'Module loaded';
+}
 
 ok Anagram.can('match'), 'Class Anagram has match method';
 

--- a/exercises/binary/binary.t
+++ b/exercises/binary/binary.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 10;
-
 BEGIN {
-  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Binary';
-  EVAL("use $module")
-};
-
-pass 'Load module';
+  plan 10;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Binary', 'Module loaded';
+}
 
 ok Binary.can('to_decimal'), 'Class Binary has to_decimal method';
 

--- a/exercises/bob/bob.t
+++ b/exercises/bob/bob.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 21;
-
-BEGIN { 
-    my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Bob';
-    EVAL("use $module");
-}; 
-
-pass 'Load module';
+BEGIN {
+  plan 21;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Bob', 'Module loaded';
+}
 
 ok Bob.can('hey'), 'Class Bob has hey() method';
 

--- a/exercises/grains/grains.t
+++ b/exercises/grains/grains.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 11;
-
 BEGIN {
-  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Grains';
-  EVAL("use $module")
-};
-
-pass 'Load module';
+  plan 11;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Grains', 'Module loaded';
+}
 
 ok Grains.can('square'), 'Grains class has square method';
 ok Grains.can('total'), 'Grains class has total method';

--- a/exercises/leap/leap.t
+++ b/exercises/leap/leap.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 8;
-
 BEGIN {
-    my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Leap';
-    EVAL("use $module");
-};
-
-pass 'Load module';
+  plan 8;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Leap', 'Module loaded';
+}
 
 ok Leap.can('is_leap'), 'Leap class has is_leap() method';
 

--- a/exercises/rna-transcription/rna_transcription.t
+++ b/exercises/rna-transcription/rna_transcription.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 7;
-
-BEGIN { 
-    my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'RNA_Transcription';
-    EVAL("use $module");
-}; 
-
-pass 'Load module';
+BEGIN {
+  plan 7;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use RNA_Transcription', 'Module loaded';
+}
 
 ok RNA_Transcription.can('to_rna'), 'Class RNA_Transcription has to_rna() method';
 

--- a/exercises/robot-name/robot.t
+++ b/exercises/robot-name/robot.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 7;
-
-BEGIN { 
-    my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Robot';
-    EVAL("use $module");
-}; 
-
-pass 'Load module';
+BEGIN {
+  plan 7;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Robot', 'Module loaded';
+}
 
 ok Robot.can('name'), 'Robot class has name attribute';
 ok Robot.can('reset_name'), 'Robot class has reset_name method';

--- a/exercises/scrabble-score/scrabble_score.t
+++ b/exercises/scrabble-score/scrabble_score.t
@@ -3,14 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 10;
-
 BEGIN {
-  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Scrabble';
-  EVAL("use $module")
-};
-
-pass 'Load module';
+  plan 10;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Scrabble', 'Module loaded';
+}
 
 ok Scrabble.can('score'), 'Scrabble class has score() method';
 

--- a/exercises/word-count/word_count.t
+++ b/exercises/word-count/word_count.t
@@ -3,15 +3,10 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 8;
-
 BEGIN {
-  my $module = %*ENV{'EXERCISM'} ?? 'Example' !! 'Word_Counter';
-  EVAL("use $module")
-};
-
-pass 'Load module';
-
+  plan 8;
+  eval-lives-ok %*ENV<EXERCISM>.so ?? 'use Example' !! 'use Word_Counter', 'Module loaded';
+}
 
 ok Word_Counter.can('count_words'), 'Class Word_Counter has count_words method';
 


### PR DESCRIPTION
1. `pass` didn't really do anything, if we didn't get past the BEGIN block it wouldn't reach that "test". `eval-lives-ok` gives us a proper test result.
2. The old `EVAL` would scream at you about how it was being used if you accidentally left out `use Test`, as `use Test` quietly exports the `MONKEY-SEE-NO-EVAL` pragma. This pragma isn't needed if `EVAL` uses literal strings, which our new test does, so if you do accidentally leave out `use Test` it will complain for the right reasons.
3. Apparently I made a mistake in a previous commit with `binary.t` and put the wrong module name in. (Now in https://github.com/exercism/xperl6/pull/53)