### PR TITLE
Task::Star in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ perl6:
   - latest
   - '2016.10'
   - '2016.07'
+install:
+  - rakudobrew build-panda
+  - panda install Task::Star
 before_script:
   - bin/fetch-configlet
 script:


### PR DESCRIPTION
As per the Perl 6 installation instructions on rakudo.org:
This will install all the modules that are shipped with the Rakudo Star Perl 6 distribution