### PR TITLE
JSON::Tiny in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ perl6:
   - latest
   - '2016.10'
   - '2016.07'
+install:
+  - rakudobrew build-panda
+  - panda install JSON::Tiny
 before_script:
   - bin/fetch-configlet
 script:


### PR DESCRIPTION
`JSON::Tiny` is part of the meta-package `Task::Star`, which contains modules shipped with the Rakudo Star Perl 6 distribution. `all-your-base.t` in #54 makes use of the `JSON::Tiny` module.