### PR TITLE
Add .precomp to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin/configlet
 bin/configlet.exe
+# dir created when a Perl 6 module is used
+.precomp


### PR DESCRIPTION
A .precomp directory is created when a test is run. Git doesn't need to worry about it.