### PR TITLE
Build with latest rakudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 ---
 sudo: false
 language: perl6
-perl6:
-  - latest
-  - '2016.10'
-  - '2016.07'
 install:
   - rakudobrew build-panda
   - panda install JSON::Tiny


### PR DESCRIPTION
Rakudo is still being worked on in regards to bug fixing and implementing Perl 6 features. We should ideally stick with the latest version and encourage other users to do so.