### PR TITLE
Remove guillemet operators

### DIFF
--- a/exercises/phone-number/Example.pm
+++ b/exercises/phone-number/Example.pm
@@ -11,8 +11,8 @@ class Phone {
   method new (:$number!) {
     my $validated = $number;
     $validated ~~ s:g/<:!Decimal_Number>//;
-    $validated ~~ /^ 1? (\d ** 10) $/ ?? ($validated = ~$0) !! X::Phone::Invalid.new(:payload«$number»).throw;
-    self.bless(:number«$validated»);
+    $validated ~~ /^ 1? (\d ** 10) $/ ?? ($validated = ~$0) !! X::Phone::Invalid.new(payload => $number).throw;
+    self.bless(number => $validated);
   }
 
   method area-code {


### PR DESCRIPTION
Previously misunderstood documentation for the « » operator.

Before:
`Phone.new(number => slip$(IntStr.new(4685551379, "4685551379"),))`

After:
`Phone.new(number => "4685551379")`