### PR TITLE
Replace panda with zef

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@
 sudo: false
 language: perl6
 install:
-  - rakudobrew build-panda
-  - panda install JSON::Tiny
+  - rakudobrew build zef
+  - zef install JSON::Tiny
 before_script:
   - bin/fetch-configlet
 script:


### PR DESCRIPTION
zef is taking the place of panda as the module installer bundled with Rakudo Star, as zef is more actively maintained.