### PR TITLE
Deprecate binary and trinary

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
   "active": false,
   "test_pattern": ".*\\.t$",
   "deprecated": [
-
+    "binary",
+    "trinary"
   ],
   "ignored": [
     "docs",
@@ -88,17 +89,7 @@
     },
     {
       "difficulty": 1,
-      "slug": "binary",
-      "topics": []
-    },
-    {
-      "difficulty": 1,
       "slug": "wordy",
-      "topics": []
-    },
-    {
-      "difficulty": 1,
-      "slug": "trinary",
       "topics": []
     },
     {


### PR DESCRIPTION
The binary and trinary exercises are to be deprecated in favour of all-your-base.

https://github.com/exercism/xperl6/pull/54 needs to be merged before this.