### PR TITLE
Update anagram exercise

### DIFF
--- a/exercises/anagram/Anagram.pm6
+++ b/exercises/anagram/Anagram.pm6
@@ -1,0 +1,1 @@
+unit module Anagram:ver<1>;

--- a/exercises/anagram/Example.pm
+++ b/exercises/anagram/Example.pm
@@ -1,18 +1,18 @@
-class Anagram is export {
-    method match ($word, @words) {
-        my @results;
-        my $canonical = self!canonize($word);
-        for @words -> $w {
-            next if $w.lc eq $word.lc;
-            my $try = self!canonize($w);
-            if $try eq $canonical {
-                @results.push: $w;
-            }
-        }
-        @results;
-    }
+unit module Anagram:ver<1>;
 
-    method !canonize($str) {
-        (($str.lc.split('')).sort).join('');
+sub match-anagrams ($word, @words) is export {
+  my @results;
+  my $canonical = canonize($word);
+  for @words -> $w {
+    next if $w.lc eq $word.lc;
+    my $try = canonize($w);
+    if $try eq $canonical {
+      @results.push: $w;
     }
+  }
+  @results;
+}
+
+sub canonize ($str) {
+  (($str.lc.split('')).sort).join('');
 }

--- a/exercises/anagram/anagram.t
+++ b/exercises/anagram/anagram.t
@@ -3,19 +3,142 @@ use v6;
 use Test;
 use lib IO::Path.new($?FILE).parent.path;
 
-plan 11;
-my $module = %*ENV<EXERCISM> ?? 'Example' !! 'Anagram';
-use-ok $module;
-require ::($module) <Anagram>;
+my $exercise = 'Anagram';
+my $version = v1;
+my $module = %*ENV<EXERCISM> ?? 'Example' !! $exercise;
+plan 18;
 
-ok Anagram.can('match'), 'Class Anagram has match method';
+use-ok $module or bail-out;
+require ::($module);
+if ::($exercise).^ver !~~ $version {
+  warn "\nExercise version mismatch. Further tests may fail!"
+    ~ "\n$exercise is $(::($exercise).^ver.gist). "
+    ~ "Test is $($version.gist).\n";
+  bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
+}
 
-is-deeply Anagram.match('diaper', ['hello', 'world', 'zombies', 'pants']), [], 'no matches';
-is-deeply Anagram.match('ant', ['tan', 'stand', 'at']), ['tan'], 'detect simple anagram';
-is-deeply Anagram.match('master', ['stream', 'pigeon', 'maters']), ['stream', 'maters'], 'multiple anagrams';
-is-deeply Anagram.match('galea', ['eagle']), [], 'does not confuse different duplicates';
-is-deeply Anagram.match('good', ['dog', 'goody']), [], 'eleminates anagram subsets';
-is-deeply Anagram.match('listen', ['enlists', 'google', 'inlets', 'banana']), ['inlets'], 'detect anagram';
-is-deeply Anagram.match('allergy', ['gallery', 'ballerina', 'regally', 'clergy', 'largely', 'leading']), ['gallery', 'regally', 'largely'], 'multiple anagrams';
-is-deeply Anagram.match('Orchestra', ['cashregister', 'Carthorse', 'radishes']), ['Carthorse'], 'anagrams are case-insensitive';
-is-deeply Anagram.match('banana', ['banana', 'Banana']), [], 'same word is not an anagram, whatever the case';
+my @subs;
+BEGIN { @subs = <&match-anagrams> };
+subtest 'Subroutine(s)', {
+  plan 1;
+  eval-lives-ok "use $module; ::('$_').defined or die '$_ is not defined.'", $_ for @subs;
+} or bail-out 'All subroutines must be defined and exported.';
+require ::($module) @subs.eager;
+
+is match-anagrams(|.<subject candidates>), |.<expected description> for @(my %c-data.<cases>);
+
+done-testing;
+
+INIT {
+  require JSON::Tiny <&from-json>;
+  %c-data := from-json ｢
+    {
+        "#": [
+            "The string argument cases possible matches are passed in as",
+            "individual arguments rather than arrays. Languages can include",
+            "these string argument cases if passing individual arguments is",
+            "idiomatic in that language.",
+            "Some tests have a \"comment\" property, which provides more",
+            "information that could be added to the test case as a code comment."
+        ],
+        "cases": [
+            {
+                "description": "no matches",
+                "subject": "diaper",
+                "candidates": [ "hello", "world", "zombies", "pants"],
+                "expected": []
+            },
+            {
+                "description": "detects simple anagram",
+                "subject": "ant",
+                "candidates": ["tan", "stand", "at"],
+                "expected": ["tan"]
+            },
+            {
+                "description": "does not detect false positives",
+                "subject": "galea",
+                "candidates": ["eagle"],
+                "expected": []
+            },
+            {
+                "description": "detects multiple anagrams",
+                "subject": "master",
+                "candidates": ["stream", "pigeon", "maters"],
+                "expected": ["stream", "maters"]
+            },
+            {
+                "description": "does not detect anagram subsets",
+                "subject": "good",
+                "candidates": ["dog", "goody"],
+                "expected": []
+            },
+            {
+                "description": "detects anagram",
+                "subject": "listen",
+                "candidates": ["enlists", "google", "inlets", "banana"],
+                "expected": ["inlets"]
+            },
+            {
+                "description": "detects multiple anagrams",
+                "subject": "allergy",
+                "candidates": ["gallery", "ballerina", "regally", "clergy", "largely", "leading"],
+                "expected": ["gallery", "regally", "largely"]
+            },
+            {
+                "description": "does not detect identical words",
+                "subject": "corn",
+                "candidates": ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"],
+                "expected": ["cron"]
+            },  
+            {
+                "description": "does not detect non-anagrams with identical checksum",
+                "subject": "mass",
+                "candidates": ["last"],
+                "expected": []
+            },
+            {
+                "description": "detects anagrams case-insensitively",
+                "subject": "Orchestra",
+                "candidates": ["cashregister", "Carthorse", "radishes"],
+                "expected": ["Carthorse"]
+            },
+            {
+                "description": "detects anagrams using case-insensitive subject",
+                "subject": "Orchestra",
+                "candidates": ["cashregister", "carthorse", "radishes"],
+                "expected": ["carthorse"]
+            },
+            {
+                "description": "detects anagrams using case-insensitive possible matches",
+                "subject": "orchestra",
+                "candidates": ["cashregister", "Carthorse", "radishes"],
+                "expected": ["Carthorse"]
+            },
+            {
+                "description": "does not detect a word as its own anagram",
+                "subject": "banana",
+                "candidates": ["Banana"],
+                "expected": []
+            },
+            {
+                "description": "does not detect a anagram if the original word is repeated",
+                "subject": "go",
+                "candidates": ["go Go GO"],
+                "expected": []
+            },
+            {
+                "description": "anagrams must use all letters exactly once",
+                "subject": "tapper",
+                "candidates": ["patter"],
+                "expected": []
+            },
+            {
+                "description": "capital word is not own anagram",
+                "subject": "BANANA",
+                "candidates": ["Banana"],
+                "expected": []
+            }
+        ]
+    }
+  ｣ 
+}

--- a/exercises/anagram/anagram.t
+++ b/exercises/anagram/anagram.t
@@ -1,12 +1,13 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib IO::Path.new($?FILE).parent.path;
+use lib my $dir = $?FILE.IO.dirname;
+use JSON::Tiny;
 
 my $exercise = 'Anagram';
 my $version = v1;
 my $module = %*ENV<EXERCISM> ?? 'Example' !! $exercise;
-plan 18;
+plan 19;
 
 use-ok $module or bail-out;
 require ::($module);
@@ -25,120 +26,145 @@ subtest 'Subroutine(s)', {
 } or bail-out 'All subroutines must be defined and exported.';
 require ::($module) @subs.eager;
 
-is match-anagrams(|.<subject candidates>), |.<expected description> for @(my %c-data.<cases>);
+is match-anagrams(|.<subject candidates>), |.<expected description> for @(my $c-data.<cases>);
+
+if %*ENV<EXERCISM> && (my $c-data-file = "$dir/../../x-common/exercises/{$dir.IO.basename}/canonical-data.json".IO.resolve) ~~ :f {
+  is-deeply $c-data, from-json($c-data-file.slurp), 'canonical-data'
+} else { skip }
 
 done-testing;
 
 INIT {
-  require JSON::Tiny <&from-json>;
-  %c-data := from-json ｢
+  $c-data := from-json ｢
     {
-        "#": [
-            "The string argument cases possible matches are passed in as",
-            "individual arguments rather than arrays. Languages can include",
-            "these string argument cases if passing individual arguments is",
-            "idiomatic in that language.",
-            "Some tests have a \"comment\" property, which provides more",
-            "information that could be added to the test case as a code comment."
-        ],
-        "cases": [
-            {
-                "description": "no matches",
-                "subject": "diaper",
-                "candidates": [ "hello", "world", "zombies", "pants"],
-                "expected": []
-            },
-            {
-                "description": "detects simple anagram",
-                "subject": "ant",
-                "candidates": ["tan", "stand", "at"],
-                "expected": ["tan"]
-            },
-            {
-                "description": "does not detect false positives",
-                "subject": "galea",
-                "candidates": ["eagle"],
-                "expected": []
-            },
-            {
-                "description": "detects multiple anagrams",
-                "subject": "master",
-                "candidates": ["stream", "pigeon", "maters"],
-                "expected": ["stream", "maters"]
-            },
-            {
-                "description": "does not detect anagram subsets",
-                "subject": "good",
-                "candidates": ["dog", "goody"],
-                "expected": []
-            },
-            {
-                "description": "detects anagram",
-                "subject": "listen",
-                "candidates": ["enlists", "google", "inlets", "banana"],
-                "expected": ["inlets"]
-            },
-            {
-                "description": "detects multiple anagrams",
-                "subject": "allergy",
-                "candidates": ["gallery", "ballerina", "regally", "clergy", "largely", "leading"],
-                "expected": ["gallery", "regally", "largely"]
-            },
-            {
-                "description": "does not detect identical words",
-                "subject": "corn",
-                "candidates": ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"],
-                "expected": ["cron"]
-            },  
-            {
-                "description": "does not detect non-anagrams with identical checksum",
-                "subject": "mass",
-                "candidates": ["last"],
-                "expected": []
-            },
-            {
-                "description": "detects anagrams case-insensitively",
-                "subject": "Orchestra",
-                "candidates": ["cashregister", "Carthorse", "radishes"],
-                "expected": ["Carthorse"]
-            },
-            {
-                "description": "detects anagrams using case-insensitive subject",
-                "subject": "Orchestra",
-                "candidates": ["cashregister", "carthorse", "radishes"],
-                "expected": ["carthorse"]
-            },
-            {
-                "description": "detects anagrams using case-insensitive possible matches",
-                "subject": "orchestra",
-                "candidates": ["cashregister", "Carthorse", "radishes"],
-                "expected": ["Carthorse"]
-            },
-            {
-                "description": "does not detect a word as its own anagram",
-                "subject": "banana",
-                "candidates": ["Banana"],
-                "expected": []
-            },
-            {
-                "description": "does not detect a anagram if the original word is repeated",
-                "subject": "go",
-                "candidates": ["go Go GO"],
-                "expected": []
-            },
-            {
-                "description": "anagrams must use all letters exactly once",
-                "subject": "tapper",
-                "candidates": ["patter"],
-                "expected": []
-            },
-            {
-                "description": "capital word is not own anagram",
-                "subject": "BANANA",
-                "candidates": ["Banana"],
-                "expected": []
-            }
-        ]
+      "exercise": "anagram",
+      "version": "1.0.1",
+      "comments": [
+        "The string argument cases possible matches are passed in as",
+        "individual arguments rather than arrays. Languages can include",
+        "these string argument cases if passing individual arguments is",
+        "idiomatic in that language."
+      ],
+      "cases": [
+        {
+          "description": "no matches",
+          "property": "anagrams",
+          "subject": "diaper",
+          "candidates": ["hello", "world", "zombies", "pants"],
+          "expected": []
+        },
+        {
+          "description": "detects simple anagram",
+          "property": "anagrams",
+          "subject": "ant",
+          "candidates": ["tan", "stand", "at"],
+          "expected": ["tan"]
+        },
+        {
+          "description": "does not detect false positives",
+          "property": "anagrams",
+          "subject": "galea",
+          "candidates": ["eagle"],
+          "expected": []
+        },
+        {
+          "description": "detects two anagrams",
+          "property": "anagrams",
+          "subject": "master",
+          "candidates": ["stream", "pigeon", "maters"],
+          "expected": ["stream", "maters"]
+        },
+        {
+          "description": "does not detect anagram subsets",
+          "property": "anagrams",
+          "subject": "good",
+          "candidates": ["dog", "goody"],
+          "expected": []
+        },
+        {
+          "description": "detects anagram",
+          "property": "anagrams",
+          "subject": "listen",
+          "candidates": ["enlists", "google", "inlets", "banana"],
+          "expected": ["inlets"]
+        },
+        {
+          "description": "detects three anagrams",
+          "property": "anagrams",
+          "subject": "allergy",
+          "candidates": [ "gallery",
+                          "ballerina",
+                          "regally",
+                          "clergy",
+                          "largely",
+                          "leading"
+                        ],
+          "expected": ["gallery", "regally", "largely"]
+        },
+        {
+          "description": "does not detect identical words",
+          "property": "anagrams",
+          "subject": "corn",
+          "candidates": ["corn", "dark", "Corn", "rank", "CORN", "cron", "park"],
+          "expected": ["cron"]
+        },
+        {
+          "description": "does not detect non-anagrams with identical checksum",
+          "property": "anagrams",
+          "subject": "mass",
+          "candidates": ["last"],
+          "expected": []
+        },
+        {
+          "description": "detects anagrams case-insensitively",
+          "property": "anagrams",
+          "subject": "Orchestra",
+          "candidates": ["cashregister", "Carthorse", "radishes"],
+          "expected": ["Carthorse"]
+        },
+        {
+          "description": "detects anagrams using case-insensitive subject",
+          "property": "anagrams",
+          "subject": "Orchestra",
+          "candidates": ["cashregister", "carthorse", "radishes"],
+          "expected": ["carthorse"]
+        },
+        {
+          "description": "detects anagrams using case-insensitive possible matches",
+          "property": "anagrams",
+          "subject": "orchestra",
+          "candidates": ["cashregister", "Carthorse", "radishes"],
+          "expected": ["Carthorse"]
+        },
+        {
+          "description": "does not detect a word as its own anagram",
+          "property": "anagrams",
+          "subject": "banana",
+          "candidates": ["Banana"],
+          "expected": []
+        },
+        {
+          "description": "does not detect a anagram if the original word is repeated",
+          "property": "anagrams",
+          "subject": "go",
+          "candidates": ["go Go GO"],
+          "expected": []
+        },
+        {
+          "description": "anagrams must use all letters exactly once",
+          "property": "anagrams",
+          "subject": "tapper",
+          "candidates": ["patter"],
+          "expected": []
+        },
+        {
+          "description": "capital word is not own anagram",
+          "property": "anagrams",
+          "subject": "BANANA",
+          "candidates": ["Banana"],
+          "expected": []
+        }
+      ]
     }
-  ｣ 
+  ｣
 }


### PR DESCRIPTION
1. Add a stub file.
2. Switch to a function. There are already a decent number of OOP exercises, and I felt it was unnecessary for this one to be. 'match' is also an existing method in Perl 6.
3. Add version.
4. Use canonical data.