### PR TITLE
Clean up .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
   - bin/fetch-configlet
 script:
   - bin/configlet .
-  - EXERCISM=1 prove -vr --exec=perl6 exercises/
+  - prove -re perl6 exercises/


### PR DESCRIPTION
1. EXERCISM env var is already set in travis.
2. -v on prove makes the logs more difficult to read if there's a failure.