### PR TITLE
Improve robot-name example

### DIFF
--- a/exercises/robot-name/Example.pm
+++ b/exercises/robot-name/Example.pm
@@ -1,11 +1,18 @@
 unit class Robot:ver<1>;
 
-state %record;
-
-has Str:D $.name = self.reset-name;
+subset Name of Str where * ~~ /^<[A..Z]>**2 <[0..9]>**3$/;
+has Name $.name = self.reset-name;
 
 method reset-name {
-  $!name = ('AA'..'ZZ').roll ~ ('000'..'999').roll;
+  state Promise:D $promise = start ('AA000'..'ZZ999').pick: *;
+  state Bool:D %record{Name:D};
+  state Int:D $i = 0;
+
+  if $promise.status ~~ 'Kept' {
+    ($!name = $promise.result[$i++]) or die 'All names used.';
+  } else {
+    $!name = ('A'..'Z').roll(2).join ~ (^10).roll(3).join;
+  }
   self.reset-name if %record{$!name}:exists;
   %record{$!name} = True;
   return $!name;


### PR DESCRIPTION
Changing `('AA'..'ZZ').roll ~ ('000'..'999').roll` shaved off about 14 seconds. I guess it makes sense that taking a random number 3 times from a list of 10 would be faster than making a list of 1000!

While the test doesn't get this far yet, continuously generating new robot names would previously cause the module to slow down and eventually hang. A `die` is now in there which will happen once all names are used up.