### PR TITLE
Run submodule command only once in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ language: perl6
 install:
   - rakudobrew build zef
   - zef install JSON::Tiny
+git:
+  submodules: false
 before_script:
-  - git submodule update --recursive --remote
+  - git submodule update --init --recursive --remote
   - bin/fetch-configlet
 script:
   - bin/configlet .


### PR DESCRIPTION
The git submodule command currently runs twice in Travis; once by default, and then again with the line in `before_script`. Unfortunately, the only option you can specify to the default submodule command is `depth`, so I've removed the default and included the `init` option in `before_script`.