### PR TITLE
Improve space-age example class exports

### DIFF
--- a/exercises/space-age/Example.pm
+++ b/exercises/space-age/Example.pm
@@ -10,21 +10,19 @@ class Earth does Planet is export {
   my $.orbital-period = 31557600;
 }
 
-my package EXPORT::DEFAULT {
-  my %planets = (
-    :Mercury(0.2408467),
-    :Venus(0.61519726),
-    :Mars(1.8808158),
-    :Jupiter(11.862615),
-    :Saturn(29.447498),
-    :Uranus(84.016846),
-    :Neptune(164.79132),
-  );
-  for %planets.kv -> $planet, $relative {
-    OUR::{$planet} := EVAL 'class :: does Planet {
-      my $.orbital-period = calculate-orbital-period $relative
-    }';
-  }
+my %planets = (
+  :Mercury(0.2408467),
+  :Venus(0.61519726),
+  :Mars(1.8808158),
+  :Jupiter(11.862615),
+  :Saturn(29.447498),
+  :Uranus(84.016846),
+  :Neptune(164.79132),
+);
+for %planets.kv -> $planet, $relative {
+  use MONKEY-SEE-NO-EVAL;
+  OUR::EXPORT::ALL::{$planet} := OUR::EXPORT::DEFAULT::{$planet} := EVAL "class $planet does Planet is export " ~
+  '{ my $.orbital-period = calculate-orbital-period $relative }';
 }
 
 sub calculate-orbital-period ($relative-to-earth) {


### PR DESCRIPTION
Gets rid of anonymous classes, and has them show up in SpaceAge::EXPORT::.