### PR TITLE
Include latest Rakudo Star version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 ---
 sudo: false
 language: perl6
+perl6:
+  - latest
+  - '2017.01' # Latest Rakudo Star
 install:
   - rakudobrew build zef
   - zef install JSON::Tiny


### PR DESCRIPTION
While writing some code today I realised I was using stuff which is in the latest Rakudo, but not yet present in Rakudo Star. We should include the latest Rakudo Star version in Travis so we don't add code which some end users may have issues with.