### PR TITLE
Include canonical-data and yaml for generator for all-your-base exercise

### DIFF
--- a/exercises/all-your-base/AllYourBase.pm6
+++ b/exercises/all-your-base/AllYourBase.pm6
@@ -1,1 +1,1 @@
-unit module AllYourBase:ver<1>;
+unit module AllYourBase:ver<2>;

--- a/exercises/all-your-base/Example.pm
+++ b/exercises/all-your-base/Example.pm
@@ -1,4 +1,4 @@
-unit module AllYourBase:ver<1>;
+unit module AllYourBase:ver<2>;
 
 class X::AllYourBase::InvalidBase is Exception {
   has $.payload;
@@ -18,7 +18,7 @@ sub convert-base (Int:D $input-base, @input-digits, Int:D $output-base --> Array
 }
 
 sub to-decimal ($input-base, @input-digits) {
-  return [] if !@input-digits;
+  return [].Slip if !@input-digits;
   my $elems = @input-digits.elems;
   for @input-digits {
     if $_ == 0 { $elems-- }

--- a/exercises/all-your-base/all-your-base.t
+++ b/exercises/all-your-base/all-your-base.t
@@ -1,15 +1,17 @@
 #!/usr/bin/env perl6
 use v6;
 use Test;
-use lib $?FILE.IO.dirname;
+use lib my $dir = $?FILE.IO.dirname;
+use JSON::Tiny;
 
 my $exercise = 'AllYourBase';
-my $version = v1;
+my $version = v2;
 my $module = %*ENV<EXERCISM> ?? 'Example' !! $exercise;
 plan 23;
 
 use-ok $module or bail-out;
 require ::($module);
+
 if ::($exercise).^ver !~~ $version {
   warn "\nExercise version mismatch. Further tests may fail!"
     ~ "\n$exercise is $(::($exercise).^ver.gist). "
@@ -17,147 +19,222 @@ if ::($exercise).^ver !~~ $version {
   bail-out 'Example version must match test version.' if %*ENV<EXERCISM>;
 }
 
-my @subs;
-BEGIN { @subs = <&convert-base> }
-subtest 'Subroutine(s)', {
-  plan 1;
-  eval-lives-ok "use $module; ::('$_').defined or die '$_ is not defined.'", $_ for @subs;
-} or bail-out 'All subroutines must be defined and exported.';
-require ::($module) @subs.eager;
+require ::($module) <&convert-base>;
 
-is convert-base(|.<input_base input_digits output_base>), |.<expected description> for @(my %cases.<valid>);
-
-my $exception = 'Exception';
-for @(%cases<invalid>) {
-  $exception = 'X::AllYourBase::Invalid' ~ (.<description> ~~ /«digit»/ ?? 'Digit' !! 'Base') if %*ENV<EXERCISM>;
-  throws-like {convert-base |.<input_base input_digits output_base>}, ::($exception), .<description>;
+my $c-data;
+sub test ($case, $expected) { is-deeply &::('convert-base')(|$case<input_base input_digits output_base>), $expected, $case<description> }
+for @($c-data<cases>) {
+  when .<expected> ~~ Array { test $_, .<expected> }
+  when .<description> ~~ /base|digit/ { throws-like {&::('convert-base')(|.<input_base input_digits output_base>)}, Exception, .<description> }
+  when .<description> eq 'leading zeros' { test $_, [4,2] }
+  when .<description> eq 'empty list' { test $_, [] }
+  when .<description> ~~ /zero/ { test $_, [0] }
+  default { flunk .<description> } # To ensure that no canonical-data cases are missed.
 }
+
+if %*ENV<EXERCISM> && (my $c-data-file =
+  "$dir/../../x-common/exercises/{$dir.IO.resolve.basename}/canonical-data.json".IO.resolve) ~~ :f
+{ is-deeply $c-data, from-json($c-data-file.slurp), 'canonical-data' } else { skip }
 
 done-testing;
 
 INIT {
-  require JSON::Tiny <&from-json>;
-  %cases := from-json ｢
+$c-data := from-json q:to/END/;
+
+{
+  "exercise": "all-your-base",
+  "version": "1.0.0",
+  "comments": [
+    "It's up to each track do decide:",
+    "",
+    "1. What's the canonical representation of zero?",
+    " - []?",
+    " - [0]?",
+    "",
+    "2. What representations of zero are allowed?",
+    " - []?",
+    " - [0]?",
+    " - [0,0]?",
+    "",
+    "3. Are leading zeroes allowed?",
+    "",
+    "4. How should invalid input be handled?",
+    "",
+    "All the undefined cases are marked as null.",
+    "",
+    "All your numeric-base are belong to [2..]. :)"
+  ],
+  "cases": [
     {
-      "valid":[
-        { "description"  : "single bit one to decimal"
-        , "input_base"   : 2
-        , "input_digits" : [1]
-        , "output_base"  : 10
-        , "expected"     : [1]
-        },
-        { "description"  : "binary to single decimal"
-        , "input_base"   : 2
-        , "input_digits" : [1, 0, 1]
-        , "output_base"  : 10
-        , "expected"     : [5]
-        },
-        { "description"  : "single decimal to binary"
-        , "input_base"   : 10
-        , "input_digits" : [5]
-        , "output_base"  : 2
-        , "expected"     : [1, 0, 1]
-        },
-        { "description"  : "binary to multiple decimal"
-        , "input_base"   : 2
-        , "input_digits" : [1, 0, 1, 0, 1, 0]
-        , "output_base"  : 10
-        , "expected"     : [4, 2]
-        },
-        { "description"  : "decimal to binary"
-        , "input_base"   : 10
-        , "input_digits" : [4, 2]
-        , "output_base"  : 2
-        , "expected"     : [1, 0, 1, 0, 1, 0]
-        },
-        { "description"  : "trinary to hexadecimal"
-        , "input_base"   : 3
-        , "input_digits" : [1, 1, 2, 0]
-        , "output_base"  : 16
-        , "expected"     : [2, 10]
-        },
-        { "description"  : "hexadecimal to trinary"
-        , "input_base"   : 16
-        , "input_digits" : [2, 10]
-        , "output_base"  : 3
-        , "expected"     : [1, 1, 2, 0]
-        },
-        { "description"  : "15-bit integer"
-        , "input_base"   : 97
-        , "input_digits" : [3,46,60]
-        , "output_base"  : 73
-        , "expected"     : [6,10,45]
-        },
-        { "description"  : "empty list outputs empty list"
-        , "input_base"   : 2
-        , "input_digits" : []
-        , "output_base"  : 10
-        , "expected"     : []
-        },
-        { "description"  : "single zero outputs 0"
-        , "input_base"   : 10
-        , "input_digits" : [0]
-        , "output_base"  : 2
-        , "expected"     : [0]
-        },
-        { "description"  : "multiple zeros outputs 0"
-        , "input_base"   : 10
-        , "input_digits" : [0, 0, 0]
-        , "output_base"  : 2
-        , "expected"     : [0]
-        },
-        { "description"  : "leading zeros are stripped"
-        , "input_base"   : 7
-        , "input_digits" : [0, 6, 0]
-        , "output_base"  : 10
-        , "expected"     : [4, 2]
-      } ],
-      "invalid":[
-        { "description"  : "negative digit is invalid"
-        , "input_base"   : 2
-        , "input_digits" : [1, -1, 1, 0, 1, 0]
-        , "output_base"  : 10
-        },
-        { "description"  : "invalid positive digit"
-        , "input_base"   : 2
-        , "input_digits" : [1, 2, 1, 0, 1, 0]
-        , "output_base"  : 10
-        },
-        { "description"  : "first base is one"
-        , "input_base"   : 1
-        , "input_digits" : []
-        , "output_base"  : 10
-        },
-        { "description"  : "second base is one"
-        , "input_base"   : 2
-        , "input_digits" : [1, 0, 1, 0, 1, 0]
-        , "output_base"  : 1
-        },
-        { "description"  : "first base is zero"
-        , "input_base"   : 0
-        , "input_digits" : []
-        , "output_base"  : 10
-        },
-        { "description"  : "second base is zero"
-        , "input_base"   : 10
-        , "input_digits" : [7]
-        , "output_base"  : 0
-        },
-        { "description"  : "first base is negative"
-        , "input_base"   : -2
-        , "input_digits" : [1]
-        , "output_base"  : 10
-        },
-        { "description"  : "second base is negative"
-        , "input_base"   : 2
-        , "input_digits" : [1]
-        , "output_base"  : -7
-        },
-        { "description"  : "both bases are negative"
-        , "input_base"   : -2
-        , "input_digits" : [1]
-        , "output_base"  : -7
-      } ]
+      "description": "single bit one to decimal",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1],
+      "output_base": 10,
+      "expected": [1]
+    },
+    {
+      "description": "binary to single decimal",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, 0, 1],
+      "output_base": 10,
+      "expected": [5]
+    },
+    {
+      "description": "single decimal to binary",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [5],
+      "output_base": 2,
+      "expected": [1, 0, 1]
+    },
+    {
+      "description": "binary to multiple decimal",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, 0, 1, 0, 1, 0],
+      "output_base": 10,
+      "expected": [4, 2]
+    },
+    {
+      "description": "decimal to binary",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [4, 2],
+      "output_base": 2,
+      "expected": [1, 0, 1, 0, 1, 0]
+    },
+    {
+      "description": "trinary to hexadecimal",
+      "property": "rebase",
+      "input_base": 3,
+      "input_digits": [1, 1, 2, 0],
+      "output_base": 16,
+      "expected": [2, 10]
+    },
+    {
+      "description": "hexadecimal to trinary",
+      "property": "rebase",
+      "input_base": 16,
+      "input_digits": [2, 10],
+      "output_base": 3,
+      "expected": [1, 1, 2, 0]
+    },
+    {
+      "description": "15-bit integer",
+      "property": "rebase",
+      "input_base": 97,
+      "input_digits": [3, 46, 60],
+      "output_base": 73,
+      "expected": [6, 10, 45]
+    },
+    {
+      "description": "empty list",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "single zero",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [0],
+      "output_base": 2,
+      "expected": null
+    },
+    {
+      "description": "multiple zeros",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [0, 0, 0],
+      "output_base": 2,
+      "expected": null
+    },
+    {
+      "description": "leading zeros",
+      "property": "rebase",
+      "input_base": 7,
+      "input_digits": [0, 6, 0],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "negative digit",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, -1, 1, 0, 1, 0],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "invalid positive digit",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, 2, 1, 0, 1, 0],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "first base is one",
+      "property": "rebase",
+      "input_base": 1,
+      "input_digits": [],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "second base is one",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1, 0, 1, 0, 1, 0],
+      "output_base": 1,
+      "expected": null
+    },
+    {
+      "description": "first base is zero",
+      "property": "rebase",
+      "input_base": 0,
+      "input_digits": [],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "second base is zero",
+      "property": "rebase",
+      "input_base": 10,
+      "input_digits": [7],
+      "output_base": 0,
+      "expected": null
+    },
+    {
+      "description": "first base is negative",
+      "property": "rebase",
+      "input_base": -2,
+      "input_digits": [1],
+      "output_base": 10,
+      "expected": null
+    },
+    {
+      "description": "second base is negative",
+      "property": "rebase",
+      "input_base": 2,
+      "input_digits": [1],
+      "output_base": -7,
+      "expected": null
+    },
+    {
+      "description": "both bases are negative",
+      "property": "rebase",
+      "input_base": -2,
+      "input_digits": [1],
+      "output_base": -7,
+      "expected": null
     }
-  ｣
+  ]
+}
+
+END
 }

--- a/exercises/all-your-base/example.yaml
+++ b/exercises/all-your-base/example.yaml
@@ -1,0 +1,14 @@
+exercise: AllYourBase
+version: 2
+plan: 23
+imports: '&convert-base'
+tests: |
+  sub test ($case, $expected) { is-deeply &::('convert-base')(|$case<input_base input_digits output_base>), $expected, $case<description> }
+  for @($c-data<cases>) {
+    when .<expected> ~~ Array { test $_, .<expected> }
+    when .<description> ~~ /base|digit/ { throws-like {&::('convert-base')(|.<input_base input_digits output_base>)}, Exception, .<description> }
+    when .<description> eq 'leading zeros' { test $_, [4,2] }
+    when .<description> eq 'empty list' { test $_, [] }
+    when .<description> ~~ /zero/ { test $_, [0] }
+    default { flunk .<description> } # To ensure that no canonical-data cases are missed.
+  }


### PR DESCRIPTION
all-your-base had previously been using a JSON adapted from canonical-data, rather than canonical-data itself. This change includes canonical-data so it can be checked for updates as other exercises would be.

A yaml file for the generator is also included.