### PR TITLE
Remove license info from README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Katrina Owen
+Copyright (c) 2017 Exercism, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -25,11 +25,6 @@ When adding a new exercise, ensure that the exercise is included in the `exercis
 Set `EXERCISM` as an environment variable (e.g. `export EXERCISM=1` in bash), and run either  `prove -re perl6`
 to run all tests in all subdirectories, or `prove -e perl6 /path/to/test.t` to run an individual test file.
 
-## License
-
-The MIT License (MIT)
-
-Copyright (c) 2014 Katrina Owen, _@kytrinyx.com
 
 ### Perl 6 icon
 The Perl 6 "Camelia" logo is owned by Larry Wall and is released under version 2.0 of the Artistic License. We are using it to identify the Perl 6 language itself, not any part of Exercism, which we believe to be admissible under fair use. The version of the logo that we are using is a pink, black and white adaptation of the logo found on <http://en.wikipedia.org/wiki/Perl_6>.


### PR DESCRIPTION
We don't need the duplication, especially now that the GitHub interface shows the
license information on the main page of the repository when it can be detected
directly from the LICENSE file.

This also updates the license file to reassign copyright to the Exercism legal entity.