### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Custom operators
 
 Raku has builtin support for Complex numbers[^complex], so this exercise focuses more on creating custom operators[^custom].

--- a/exercises/practice/custom-set/.docs/instructions.append.md
+++ b/exercises/practice/custom-set/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Set Operators
 
 `raku` has [built-in set support.](https://docs.raku.org/language/setbagmix)

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,2 +1,6 @@
+# Instructions append
+
+## Implementation
+
 Raku is aware of leap seconds.
 If the tests are seconds off then this may be a cause to work around.

--- a/exercises/practice/micro-blog/.docs/instructions.append.md
+++ b/exercises/practice/micro-blog/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Unicode support
 
 raku supports Unicode version 17 as of release 2025-12[^changelog].

--- a/exercises/practice/nth-prime/.docs/instructions.append.md
+++ b/exercises/practice/nth-prime/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Parallelism
 
 The test runner has access to two cores as of 2025-07-28.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.